### PR TITLE
Add support for commas in portal names

### DIFF
--- a/makePlan.py
+++ b/makePlan.py
@@ -37,6 +37,7 @@ Options:
 """
 
 import sys
+import csv
 from docopt import docopt
 
 import networkx as nx
@@ -90,9 +91,7 @@ def main():
 		i = 0
 		# each line should be id,name,lat,long,keys
 		with open(input_file,'r') as fin:
-			for line in fin:
-				parts = line.split(',')
-
+			for parts in csv.reader(fin):
 				if len(parts) < 3:
 					break
 


### PR DESCRIPTION
Lines like `"Het Leven, De Wietel",51323152,5978139` used to crash the script. This was solved by using the python `csv` module, instead of simply splitting a string at every comma.

Issue previously caused:

```
Traceback (most recent call last):
  File "makePlan.py", line 215, in <module>
    sys.exit(main())
  File "makePlan.py", line 102, in main
    locs.append( np.array(parts[1:3],dtype=int) )
ValueError: invalid literal for long() with base 10: ' De Wietel"'
```
