### PR TITLE
Use lowercase names for alphabetical order

### DIFF
--- a/lib/PlanPrinter.py
+++ b/lib/PlanPrinter.py
@@ -49,7 +49,8 @@ class PlanPrinter:
 
         self.names = np.array([a.node[i]['name'] for i in xrange(self.n)])
         # The alphabetical order
-        self.nameOrder = np.argsort(self.names)
+        makeLowerCase = np.vectorize(lambda s: s.lower())
+        self.nameOrder = np.argsort(makeLowerCase(self.names))
 
         self.xy = np.array([self.a.node[i]['xy'] for i in xrange(self.n)])
 


### PR DESCRIPTION
Order of `keyPrep.txt` is inconsistent with the in-game sorting order of portals. This is because the game uses a case-insensitive sort, whereas the script uses a case-sensitive order. Fixed by generating the name-sorted index array based on lowercased portal names.

Before:

```
Kub (Palladio)
Kunst Voor Het Gemeentehuis
Modern Art Sofa
Pantaleon Jule 2007
kunst van wonen limburg
moskee panningen
```

After:

```
Kub (Palladio)
kunst van wonen limburg
Kunst Voor Het Gemeentehuis
Modern Art Sofa
moskee panningen
Pantaleon Jule 2007
```
