### PR TITLE
Resolve conflict in doc string

### DIFF
--- a/makePlan.py
+++ b/makePlan.py
@@ -36,6 +36,12 @@ Options:
 
 """
 
+import sys
+from docopt import docopt
+import networkx as nx
+from lib import maxfield,PlanPrinter,geometry,agentOrder
+import pickle
+
 args = sys.argv
 
 # We will take many samples in an attempt to reduce number of keys to farm
@@ -74,12 +80,6 @@ if len(args) < 3:
                  default: "lastPlan.pkl"
     '''
     exit()
-
-import sys
-from docopt import docopt
-import networkx as nx
-from lib import maxfield,PlanPrinter,geometry,agentOrder
-import pickle
 
 def main():
 	args = docopt(__doc__)


### PR DESCRIPTION
Fixed an unresolved merge conflict which allowed git diff markers to be
commited. These then went on to cause more merge conflicts later on.
Unfortunately the way I solved this made the git log look like a bit of
a pyramid but at least I think it shows clearly how this was solved.
